### PR TITLE
Use Node LTS to fix package restore error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
   publish = "dist"
   command = "yarn generate"
 [build.environment]
-  NODE_VERSION = "11"
+  NODE_VERSION = "14"


### PR DESCRIPTION
Fixes:

1:52:00 PM: error nanoid@3.1.12: The engine "node" is incompatible with this module. Expected version "^10 || ^12 || >=13.7". Got "11.15.0"

cc @sdras 